### PR TITLE
Updated tests & converted unsafe calls to safe ones

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,3 +1,4 @@
 Ivar Nymoen <ivar.nymoen@gmail.com>
 João Cristóvão <jmacristovao@gmail.com>
 Jakub Stasiak <jakub@stasiak.at>
+Will Martino <wjmartino@gmail.com>

--- a/nanomsg-haskell.cabal
+++ b/nanomsg-haskell.cabal
@@ -1,5 +1,5 @@
 name:                nanomsg-haskell
-version:             0.2.2
+version:             0.2.3
 synopsis:
   Bindings to the nanomsg library
 description:

--- a/src/Nanomsg.hsc
+++ b/src/Nanomsg.hsc
@@ -327,52 +327,52 @@ throwErrnoIfMinus1RetryMayBlock_ = throwErrnoIfRetryMayBlock_ (== -1)
 -- * FFI functions
 
 -- NN_EXPORT int nn_socket (int domain, int protocol);
-foreign import ccall unsafe "nn.h nn_socket"
+foreign import ccall safe "nn.h nn_socket"
     c_nn_socket :: CInt -> CInt -> IO CInt
 
 -- NN_EXPORT int nn_bind (int s, const char *addr);
-foreign import ccall unsafe "nn.h nn_bind"
+foreign import ccall safe "nn.h nn_bind"
     c_nn_bind :: CInt -> CString -> IO CInt
 
 -- NN_EXPORT int nn_connect (int s, const char *addr);
-foreign import ccall unsafe "nn.h nn_connect"
+foreign import ccall safe "nn.h nn_connect"
     c_nn_connect :: CInt -> CString -> IO CInt
 
 -- NN_EXPORT int nn_shutdown (int s, int how);
-foreign import ccall unsafe "nn.h nn_shutdown"
+foreign import ccall safe "nn.h nn_shutdown"
     c_nn_shutdown :: CInt -> CInt -> IO CInt
 
 -- NN_EXPORT int nn_send (int s, const void *buf, size_t len, int flags);
-foreign import ccall unsafe "nn.h nn_send"
+foreign import ccall safe "nn.h nn_send"
     c_nn_send :: CInt -> CString -> CInt -> CInt -> IO CInt
 
 -- NN_EXPORT int nn_recv (int s, void *buf, size_t len, int flags);
-foreign import ccall unsafe "nn.h nn_recv"
+foreign import ccall safe "nn.h nn_recv"
     c_nn_recv :: CInt -> Ptr CString -> CInt -> CInt -> IO CInt
 
 -- NN_EXPORT int nn_freemsg (void *msg);
-foreign import ccall unsafe "nn.h nn_freemsg"
+foreign import ccall safe "nn.h nn_freemsg"
     c_nn_freemsg :: Ptr CChar -> IO CInt
 
 -- NN_EXPORT int nn_close (int s);
-foreign import ccall unsafe "nn.h nn_close"
+foreign import ccall safe "nn.h nn_close"
     c_nn_close :: CInt -> IO CInt
 
 -- NN_EXPORT void nn_term (void);
-foreign import ccall unsafe "nn.h nn_term"
+foreign import ccall safe "nn.h nn_term"
     c_nn_term :: IO ()
 
 -- NN_EXPORT int nn_setsockopt (int s, int level, int option, const void *optval, size_t optvallen);
-foreign import ccall unsafe "nn.h nn_setsockopt"
+foreign import ccall safe "nn.h nn_setsockopt"
     c_nn_setsockopt :: CInt -> CInt -> CInt -> Ptr a -> CInt -> IO CInt
 
 -- NN_EXPORT int nn_getsockopt (int s, int level, int option, void *optval, size_t *optvallen);
-foreign import ccall unsafe "nn.h nn_getsockopt"
+foreign import ccall safe "nn.h nn_getsockopt"
     c_nn_getsockopt :: CInt -> CInt -> CInt -> Ptr a -> Ptr CInt -> IO CInt
 
 -- /*  Resolves system errors and native errors to human-readable string.        */
 -- NN_EXPORT const char *nn_strerror (int errnum);
-foreign import ccall unsafe "nn.h nn_strerror"
+foreign import ccall safe "nn.h nn_strerror"
     c_nn_strerror :: CInt -> IO CString
 
 -- /*  This function retrieves the errno as it is known to the library.          */
@@ -380,7 +380,7 @@ foreign import ccall unsafe "nn.h nn_strerror"
 -- /*  where the library is compiled with certain CRT library (on Windows) and   */
 -- /*  linked to an application that uses different CRT library.                 */
 -- NN_EXPORT int nn_errno (void);
-foreign import ccall unsafe "nn.h nn_errno"
+foreign import ccall safe "nn.h nn_errno"
     c_nn_errno :: IO CInt
 
 {-

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Main where
 
@@ -24,7 +25,7 @@ prop_reverse xs =
 -- test Pub and Sub sockets
 prop_PubSub :: Property
 prop_PubSub = monadicIO $ do
-    msgs <- pick arbitrary
+    (msgs :: [ByteString]) <- pick arbitrary
     pre $ not (null msgs)
     res <- run $ do
         pub <- socket Pub
@@ -61,7 +62,7 @@ prop_PubSub = monadicIO $ do
 -- test Pair sockets
 prop_Pair :: Property
 prop_Pair = monadicIO $ do
-    msgs <- pick arbitrary
+    (msgs :: [ByteString]) <- pick arbitrary
     pre $ not (null msgs)
     res <- run $ do
         s1 <- socket Pair
@@ -80,7 +81,7 @@ prop_Pair = monadicIO $ do
 -- test Pipeline (Push & Pull) sockets
 prop_Pipeline :: Property
 prop_Pipeline = monadicIO $ do
-    msgs <- pick arbitrary
+    (msgs :: [ByteString]) <- pick arbitrary
     pre $ not (null msgs)
     res <- run $ do
         push <- socket Push
@@ -115,7 +116,7 @@ prop_Pipeline = monadicIO $ do
 -- test Req and Rep sockets
 prop_ReqRep :: Property
 prop_ReqRep = monadicIO $ do
-    msgs <- pick arbitrary
+    (msgs :: [ByteString]) <- pick arbitrary
     pre $ not (null msgs)
     res <- run $ do
         req <- socket Req
@@ -133,7 +134,7 @@ prop_ReqRep = monadicIO $ do
 -- test Bus socket
 prop_Bus :: Property
 prop_Bus = monadicIO $ do
-    msgs <- pick arbitrary
+    (msgs :: [ByteString]) <- pick arbitrary
     pre $ not (null msgs)
     res <- run $ do
         -- Probably not how you're supposed to connect Bus nodes..


### PR DESCRIPTION
I changed `unsafe` calls to `safe` for better runtime system interaction - so we can use the bindings with multithreading and not lock the world. This was at the behest of @cartazio so he may have more comments on why. Was there any specific reason not to use `safe` for the FFI? I was unable to find one in the docs but could have missed something.

Also, I updated the tests so that they would build. Not sure what changed to cause them to not build thought I think it is due to me using 7.10.